### PR TITLE
Fix. Heap Corruption Exception 0xC0000374

### DIFF
--- a/src/server/shared/Database/MySQLConnection.cpp
+++ b/src/server/shared/Database/MySQLConnection.cpp
@@ -67,7 +67,8 @@ MySQLConnection::~MySQLConnection()
         free((void *)m_queries[itr->first].first);
 
     mysql_close(m_Mysql);
-    delete m_Mysql;
+    /* Heap Corruption Exception 0xC0000374.
+	delete m_Mysql; */
     m_Mysql = NULL;
 }
 


### PR DESCRIPTION
It is not necessary to delete `mysql-object` after mysql_close(MYSQL*)